### PR TITLE
remove exact pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 compliance-checker>=2.2.0
-isodate==0.5.4
-six==1.10.0
+isodate>=0.5.4
+six>=1.10.0


### PR DESCRIPTION
This should help maintain packages downstream and I could not find any reason for the exact pins here.